### PR TITLE
fixed checking if all vms are running and two minor fixes

### DIFF
--- a/ansible/git-install.sh
+++ b/ansible/git-install.sh
@@ -39,8 +39,9 @@ function with_root {
   local SHELL_INVOCATION=$@
   if [ "$USER" = "root" ]; then
     $SHELL_INVOCATION
-  elif [ -z "$PS1" ]; then
-    # non interactive shell
+  # elif [ -z "$PS1" ]; then
+  elif [ "$(tty)" == "not a tty" ]; then
+      # non interactive shell
     sudo -n $SHELL_INVOCATION
   else
     sudo $SHELL_INVOCATION

--- a/vagrant/ssh-ansible.sh
+++ b/vagrant/ssh-ansible.sh
@@ -45,15 +45,15 @@ if [ ! -z $VAGRANT_SSH_ARGS ]; then
   VAGRANT_SSH_ARGS=" -- $VAGRANT_SSH_ARGS"
 fi
 
-:: --- vagrant requires to be in the folder ---
+#  --- vagrant requires to be in the folder ---
 pushd $PROJECT_FOLDER
 
 # --- check that all vagrant machines are up ---
-vagrant status | read ; while read first second third fourth fifth; do
-  if [ ! -z $fifth ]; then
-    break
+vagrant status --machine-readable | while IFS=, read time name kind state; do
+  if [ "$kind" != "state" ]; then
+    continue
   fi
-  if [ ! "$second" == "running" ]; then
+  if [ "$state" != "running" ]; then
     vagrant up
     break
   fi


### PR DESCRIPTION
Thanks to the [`--machine-readable` flag](https://docs.vagrantup.com/v2/cli/machine-readable.html)  we can solve the problem in a more reliable way than the solution we hacked on Wednesday at the HQ.

Another approach I tested first was

``` bash
num_not_running=$(vagrant status --machine-readable \
                       | grep -E "^[0-9]+,[^,]+,state," \
                       | grep -vE "^[0-9]+,[^,]+,state,running" \
                       | wc -l)

[[ ($num_not_running > 0) ]] &&  vagrant up
```

Just for the sake of completeness, the `awk`(ward) way that I've dropped was:

``` bash
num_not_running=$(vagrant status | awk '(!/running/ && NR > 2) {if ( NF == 0) {exit;}; print $1}'| wc -l)

[[ ($num_not_running > 0) ]] &&  vagrant up
```
