### PR TITLE
Fixed ansible git install (remove old version)

### DIFF
--- a/ansible/run.sh
+++ b/ansible/run.sh
@@ -80,8 +80,14 @@ if [ -x "$ANSIBLE_RUN_HOSTS" ]; then
 fi
 
 # --- use non system Ansible ---
-if [ "$SOURCE_ANSIBLE" == true ]; then
-  echo -e "${GREEN}Using Ansible from ${ANSIBLE_DIR} v$(cat $ANSIBLE_DIR/VERSION)${NORMAL}"
+if [ "$SOURCE_ANSIBLE" == true ]; then # TODO fix me if VERSION does not exist
+  if [ -f ${ANSIBLE_DIR}/VERSION ]; then
+    ANSIBLE_SRC_VERSION=$(cat $ANSIBLE_DIR/VERSION)
+  elif [ -f ${ANSIBLE_DIR}/lib/ansible/release.py  ]; then
+    ANSIBLE_SRC_VERSION=$(cat ${ANSIBLE_DIR}/lib/ansible/release.py | sed -rn "s/__version__ = '(.+)'/\1/p")
+  fi
+
+  echo -e "${GREEN}Using Ansible from ${ANSIBLE_DIR} v${ANSIBLE_SRC_VERSION}${NORMAL}"
   cd $ANSIBLE_DIR # switch folder otherwise vagrant folder might not work
   set +e
   source ${ANSIBLE_DIR}/hacking/env-setup


### PR DESCRIPTION
The `VERSION` file was remove from the Ansible repository that was used by `git-install.sh` to check if a new version has to be installed.

I added a check if `/lib/ansible/release.py` exists and extract the version from it. I also updated the `run.sh` which also used the `VERSION` file to echo the currently used version and added the `python-setuptools` dependency which is needed for newer Ansible versions.